### PR TITLE
change getConnection from synchronous to asynchronous

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -21,27 +21,28 @@ let logConfig = require('../log_config');
  * @constructor
  */
 function Client(configs) {
-    if(!(this instanceof Client)){
+    if (!(this instanceof Client)) {
         return new Client(configs);
     }
     EventEmitter.call(this);
 
     this.rpcTimeOut = configs.operationTimeout || _OPERATION_TIMEOUT;
     this.metaList = configs.metaServers;
-    if(configs.log){
+    if (configs.log) {
         this.log = configs.log;
-    }else{
+    } else {
         log4js.configure(logConfig);
         this.log = log4js.getLogger('pegasus');
     }
 
     this.cachedTableInfo = {};          //tableName -> tableInfo
     this.cluster = new Cluster({        //Current connections
-        'metaList' : this.metaList,
-        'timeout' : this.rpcTimeOut,
-        'log' : this.log,
+        'metaList': this.metaList,
+        'timeout': this.rpcTimeOut,
+        'log': this.log,
     });
 }
+
 util.inherits(Client, EventEmitter);
 
 /**
@@ -54,7 +55,7 @@ util.inherits(Client, EventEmitter);
  * @return  {Client}  client instance
  * @throws  {InvalidParamException}
  */
-Client.create = function(configs) {
+Client.create = function (configs) {
     tools.validateClientConfigs(configs);
     return new Client(configs);
 };
@@ -62,7 +63,7 @@ Client.create = function(configs) {
 /**
  * Close client and it sessions
  */
-Client.prototype.close = function(){
+Client.prototype.close = function () {
     this.cluster.close();
 };
 
@@ -76,16 +77,16 @@ Client.prototype.close = function(){
  * @param {Function}    callback
  * @throws{InvalidParamException} callback is not function
  */
-Client.prototype.get = function(tableName, args, callback){
+Client.prototype.get = function (tableName, args, callback) {
     tools.validateFunction(callback, 'callback');
-    if( tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback) ||
-        tools.validateParam(args.sortKey, 'sortKey', Buffer, true, callback)){
+    if (tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback) ||
+        tools.validateParam(args.sortKey, 'sortKey', Buffer, true, callback)) {
         return;
     }
-    this.getTable(tableName, function(err, tableInfo){
-        if(err === null && tableInfo !== null) {
+    this.getTable(tableName, function (err, tableInfo) {
+        if (err === null && tableInfo !== null) {
             tableInfo.get(args, callback);
-        }else{
+        } else {
             callback(err, null);
         }
     });
@@ -103,17 +104,17 @@ Client.prototype.get = function(tableName, args, callback){
  * @param {Function}    callback
  * @throws{InvalidParamException} callback is not function
  */
-Client.prototype.set = function(tableName, args, callback){
+Client.prototype.set = function (tableName, args, callback) {
     tools.validateFunction(callback, 'callback');
-    if( tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback) ||
+    if (tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback) ||
         tools.validateParam(args.sortKey, 'sortKey', Buffer, true, callback) ||
-        tools.validateParam(args.value, 'value', Buffer, true, callback)){
+        tools.validateParam(args.value, 'value', Buffer, true, callback)) {
         return;
     }
-    this.getTable(tableName, function(err, tableInfo){
-        if(err === null && tableInfo !== null){
+    this.getTable(tableName, function (err, tableInfo) {
+        if (err === null && tableInfo !== null) {
             tableInfo.set(args, callback);
-        }else{
+        } else {
             callback(err, null);
         }
     });
@@ -131,21 +132,23 @@ Client.prototype.set = function(tableName, args, callback){
  * @param {Function}    callback
  * @throws{InvalidParamException} callback is not function
  */
-Client.prototype.batchSet = function(tableName, argsArray, callback){
+Client.prototype.batchSet = function (tableName, argsArray, callback) {
     tools.validateFunction(callback, 'callback');
-    if(tools.validateParam(argsArray, 'argsArray', Array, true, callback)){return;}
+    if (tools.validateParam(argsArray, 'argsArray', Array, true, callback)) {
+        return;
+    }
     let i, len = argsArray.length;
-    for(i = 0; i < len; ++i){
-        if( tools.validateParam(argsArray[i].hashKey, 'hashKey', Buffer, true, callback) ||
+    for (i = 0; i < len; ++i) {
+        if (tools.validateParam(argsArray[i].hashKey, 'hashKey', Buffer, true, callback) ||
             tools.validateParam(argsArray[i].sortKey, 'sortKey', Buffer, true, callback) ||
-            tools.validateParam(argsArray[i].value, 'value', Buffer, true, callback)){
+            tools.validateParam(argsArray[i].value, 'value', Buffer, true, callback)) {
             return;
         }
     }
-    this.getTable(tableName, function(err, tableInfo){
-        if(err === null && tableInfo !== null){
+    this.getTable(tableName, function (err, tableInfo) {
+        if (err === null && tableInfo !== null) {
             tableInfo.batchSetPromise(argsArray, callback);
-        }else{
+        } else {
             callback(err, null);
         }
     });
@@ -161,20 +164,22 @@ Client.prototype.batchSet = function(tableName, argsArray, callback){
  * @param {Function}    callback
  * @throws{InvalidParamException} callback is not function
  */
-Client.prototype.batchGet = function(tableName, argsArray, callback){
+Client.prototype.batchGet = function (tableName, argsArray, callback) {
     tools.validateFunction(callback, 'callback');
-    if(tools.validateParam(argsArray, 'argsArray', Array, true, callback)){return;}
+    if (tools.validateParam(argsArray, 'argsArray', Array, true, callback)) {
+        return;
+    }
     let i, len = argsArray.length;
-    for(i = 0; i < len; ++i){
-        if( tools.validateParam(argsArray[i].hashKey, 'hashKey', Buffer, true, callback) ||
-            tools.validateParam(argsArray[i].sortKey, 'sortKey', Buffer, true, callback)){
+    for (i = 0; i < len; ++i) {
+        if (tools.validateParam(argsArray[i].hashKey, 'hashKey', Buffer, true, callback) ||
+            tools.validateParam(argsArray[i].sortKey, 'sortKey', Buffer, true, callback)) {
             return;
         }
     }
-    this.getTable(tableName, function(err, tableInfo){
-        if(err === null && tableInfo !== null){
+    this.getTable(tableName, function (err, tableInfo) {
+        if (err === null && tableInfo !== null) {
             tableInfo.batchGetPromise(argsArray, callback);
-        }else{
+        } else {
             callback(err, null);
         }
     });
@@ -190,16 +195,16 @@ Client.prototype.batchGet = function(tableName, argsArray, callback){
  * @param {Function}    callback
  * @throws{InvalidParamException} callback is not function
  */
-Client.prototype.del = function(tableName, args, callback){
+Client.prototype.del = function (tableName, args, callback) {
     tools.validateFunction(callback, 'callback');
-    if( tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback) ||
-        tools.validateParam(args.sortKey, 'sortKey', Buffer, true, callback)){
+    if (tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback) ||
+        tools.validateParam(args.sortKey, 'sortKey', Buffer, true, callback)) {
         return;
     }
-    this.getTable(tableName, function(err, tableInfo){
-        if(err === null && tableInfo !== null) {
+    this.getTable(tableName, function (err, tableInfo) {
+        if (err === null && tableInfo !== null) {
             tableInfo.del(args, callback);
-        }else{
+        } else {
             callback(err, null);
         }
     });
@@ -218,18 +223,24 @@ Client.prototype.del = function(tableName, args, callback){
  * @param {Function}    callback
  * @throws{InvalidParamException} callback is not function
  */
-Client.prototype.multiGet = function(tableName, args, callback){
+Client.prototype.multiGet = function (tableName, args, callback) {
     tools.validateFunction(callback, 'callback');
-    if(tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback)){return;}
-    if(tools.validateParam(args.sortKeyArray, 'sortKeyArray', Array, true, callback)){return;}
-    let i, len = args.sortKeyArray.length;
-    for(i = 0; i < len; ++i){
-        if( tools.validateParam(args.sortKeyArray[i], 'sortKey', Buffer, true, callback)){return;}
+    if (tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback)) {
+        return;
     }
-    this.getTable(tableName, function(err, tableInfo){
-        if(err === null && tableInfo !== null) {
+    if (tools.validateParam(args.sortKeyArray, 'sortKeyArray', Array, true, callback)) {
+        return;
+    }
+    let i, len = args.sortKeyArray.length;
+    for (i = 0; i < len; ++i) {
+        if (tools.validateParam(args.sortKeyArray[i], 'sortKey', Buffer, true, callback)) {
+            return;
+        }
+    }
+    this.getTable(tableName, function (err, tableInfo) {
+        if (err === null && tableInfo !== null) {
             tableInfo.multiGet(args, callback);
-        }else{
+        } else {
             callback(err, null);
         }
     });
@@ -247,21 +258,25 @@ Client.prototype.multiGet = function(tableName, args, callback){
  * @param {Function}    callback
  * @throws{InvalidParamException} callback is not function
  */
-Client.prototype.multiSet = function(tableName, args, callback){
+Client.prototype.multiSet = function (tableName, args, callback) {
     tools.validateFunction(callback, 'callback');
-    if(tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback)){return;}
-    if(tools.validateParam(args.sortKeyValueArray, 'sortKeyValueArray', Array, true, callback)){return;}
+    if (tools.validateParam(args.hashKey, 'hashKey', Buffer, true, callback)) {
+        return;
+    }
+    if (tools.validateParam(args.sortKeyValueArray, 'sortKeyValueArray', Array, true, callback)) {
+        return;
+    }
     let i, len = args.sortKeyValueArray.length;
-    for(i = 0; i < len; ++i){
-        if( tools.validateParam(args.sortKeyValueArray[i].key, 'sortKey', Buffer, true, callback) ||
-            tools.validateParam(args.sortKeyValueArray[i].value, 'value', Buffer, true, callback)){
+    for (i = 0; i < len; ++i) {
+        if (tools.validateParam(args.sortKeyValueArray[i].key, 'sortKey', Buffer, true, callback) ||
+            tools.validateParam(args.sortKeyValueArray[i].value, 'value', Buffer, true, callback)) {
             return;
         }
     }
-    this.getTable(tableName, function(err, tableInfo){
-        if(err === null && tableInfo !== null) {
+    this.getTable(tableName, function (err, tableInfo) {
+        if (err === null && tableInfo !== null) {
             tableInfo.multiSet(args, callback);
-        }else{
+        } else {
             callback(err, null);
         }
     });
@@ -272,21 +287,23 @@ Client.prototype.multiSet = function(tableName, args, callback){
  * @param {String}      tableName
  * @param {Function}    callback
  */
-Client.prototype.getTable = function(tableName, callback){
-    if(tools.validateParam(tableName, 'tableName', 'string', false, callback)) {return;}
+Client.prototype.getTable = function (tableName, callback) {
+    if (tools.validateParam(tableName, 'tableName', 'string', false, callback)) {
+        return;
+    }
     let self = this;
     let tableInfo = self.cachedTableInfo[tableName];
-    if(!tableInfo){
-        new TableHandler(self.cluster, tableName, function(err, tableHandler){
-            if(err === null && tableHandler !== null) {
+    if (!tableInfo) {
+        new TableHandler(self.cluster, tableName, function (err, tableHandler) {
+            if (err === null && tableHandler !== null) {
                 tableInfo = new TableInfo(self, tableHandler, self.rpcTimeOut);
                 self.cachedTableInfo[tableName] = tableInfo;
                 callback(err, tableInfo);
-            }else{
+            } else {
                 callback(err, null);
             }
         });
-    }else{  //use cached tableInfo structure
+    } else {  //use cached tableInfo structure
         callback(null, tableInfo);
     }
 };

--- a/src/connection.js
+++ b/src/connection.js
@@ -219,7 +219,7 @@ Connection.prototype.setupStream = function () {
     self.socket.on('connect', function () {
         this._connected = true;
         self.getResponse();
-        self.emit('connect'); //TODO(hyc): check handler of connection's connect event
+        self.emit('connect');
         log.info('Connected to %s', self.name);
     });
 };
@@ -239,7 +239,7 @@ Connection.prototype.call = function (entry) {
     rpcRequest.on('done', function (err, operator) {
         delete self.requests[rpcRequest.id];
         if (err) {
-            log.error(err.message);
+            log.debug(err.message);
         }
         entry.callback(err, operator);
     });
@@ -347,7 +347,7 @@ Request.prototype.handleTimeout = function () {
  */
 Request.prototype.setException = function (err) {
     if (err.message.indexOf('no error') < 0) {
-        log.error('setException: %s request#%d error %s', this.connection.name, this.id, err.message);
+        log.error('setException: %s request#%d error: %s', this.connection.name, this.id, err.message);
     }
     this.error = err;
     if (err.err_type === 'ERR_SESSION_RESET') {

--- a/src/connection.js
+++ b/src/connection.js
@@ -30,7 +30,7 @@ let log = null;
  *        {Object}  options.protocol        optional
  * @constructor
  */
-function Connection (options) {
+function Connection(options) {
     log = options.log;
     this.id = ++_seq_id;
     this.host = options.host;
@@ -54,6 +54,7 @@ function Connection (options) {
 
     this.setupStream();
 }
+
 util.inherits(Connection, EventEmitter);
 
 Connection.Request_counter = 0; //total request for one client
@@ -61,7 +62,7 @@ Connection.Request_counter = 0; //total request for one client
 /**
  * Set up connection and register events
  */
-Connection.prototype.setupConnection = function(){
+Connection.prototype.setupConnection = function () {
     this.socket = net.connect(this.address);
     //register socket event
     this.socket.on('timeout', this._handleTimeout.bind(this));
@@ -75,7 +76,7 @@ Connection.prototype.setupConnection = function(){
  * Handle socket timeout
  * @private
  */
-Connection.prototype._handleTimeout = function(){
+Connection.prototype._handleTimeout = function () {
     this._close(new Exception.ConnectionClosedException('%s socket closed by timeout', this.name));
 };
 
@@ -83,7 +84,7 @@ Connection.prototype._handleTimeout = function(){
  * Handle socket close
  * @private
  */
-Connection.prototype._handleClose = function(){
+Connection.prototype._handleClose = function () {
     log.debug('%s close event emit', this.name);
     this.closed = true;
     this.emit('close');
@@ -107,10 +108,10 @@ Connection.prototype._handleError = function (err) {
     if (err.message.indexOf('ECONNREFUSED') >= 0) {
         errorName = 'ConnectionRefusedException';
         err = new Exception.RPCException('ERR_SESSION_RESET', this.name + ' error: ' + errorName + ', ' + err.message);
-    }else if (err.message.indexOf('ECONNRESET') >= 0 || err.message.indexOf('This socket is closed') >= 0) {
+    } else if (err.message.indexOf('ECONNRESET') >= 0 || err.message.indexOf('This socket is closed') >= 0) {
         errorName = 'ConnectionResetException';
         err = new Exception.RPCException('ERR_SESSION_RESET', this.name + ' error: ' + errorName + ', ' + err.message);
-    }else{
+    } else {
         err = new Exception.RPCException('ERR_SESSION_RESET', this.name + ' error: ' + errorName + ', ' + err.message);
         // err = new Exception.ConnectionClosedException(this.name + ' error: ' + errorName + ', ' + err.message);
     }
@@ -129,14 +130,14 @@ Connection.prototype._handleError = function (err) {
  * @param err
  * @private
  */
-Connection.prototype._cleanupRequests = function(err){
+Connection.prototype._cleanupRequests = function (err) {
     let count = 0;
     let requests = this.requests;
     // if(requests.length === 0){
     //     return;
     // }
     this.requests = {};
-    for(let id in requests){
+    for (let id in requests) {
         let request = requests[id];
         request.setException(err);
         count++;
@@ -149,7 +150,7 @@ Connection.prototype._cleanupRequests = function(err){
  * @param {ConnectionClosedException} err
  * @private
  */
-Connection.prototype._close = function(err){
+Connection.prototype._close = function (err) {
     this.closed = true;
     this._closeError = err;
     this.socket.destroy();
@@ -159,9 +160,9 @@ Connection.prototype._close = function(err){
 /**
  * Register data event for socket to receive response
  */
-Connection.prototype.getResponse = function(){
+Connection.prototype.getResponse = function () {
     let self = this;
-    this.socket.on('data', self.transport.receiver(function(transport_with_data){
+    this.socket.on('data', self.transport.receiver(function (transport_with_data) {
         let protocol = new self.protocol(transport_with_data);
         try {
             while (true) {
@@ -170,7 +171,7 @@ Connection.prototype.getResponse = function(){
                 let len = protocol.readI32();
 
                 // current packet is NOT integrated
-                if(transport_with_data.writeCursor - startReadCursor < len){
+                if (transport_with_data.writeCursor - startReadCursor < len) {
                     transport_with_data.rollbackPosition();
                     break;
                 }
@@ -199,7 +200,7 @@ Connection.prototype.getResponse = function(){
                 transport_with_data.commitPosition();
             }
 
-        } catch(e){
+        } catch (e) {
             if (e instanceof InputBufferUnderrunError) {
                 transport_with_data.rollbackPosition();
             }
@@ -213,14 +214,14 @@ Connection.prototype.getResponse = function(){
 /**
  * Set up socket stream
  */
-Connection.prototype.setupStream = function(){
+Connection.prototype.setupStream = function () {
     let self = this;
     log.debug('Connecting to %s', self.name);
 
     self.setupConnection();
     self.out = new DataOutputStream(this.socket);
 
-    self.socket.on('connect', function (){
+    self.socket.on('connect', function () {
         this._connected = true;
         self.getResponse();
         self.emit('connect');
@@ -232,7 +233,7 @@ Connection.prototype.setupStream = function(){
  * Send request and register request events
  * @param entry
  */
-Connection.prototype.call = function(entry){
+Connection.prototype.call = function (entry) {
     let timeout = entry.operator.timeout;
     let self = this;
     let connectionRequestId = self._requestNums++;
@@ -240,19 +241,19 @@ Connection.prototype.call = function(entry){
     let rpcRequest = new Request(this, connectionRequestId, entry, timeout);
     self.requests[rpcRequest.id] = rpcRequest;
 
-    rpcRequest.on('done', function(err, operator){
+    rpcRequest.on('done', function (err, operator) {
         delete self.requests[rpcRequest.id];
-        if(err){
+        if (err) {
             log.error(err.message);
         }
         entry.callback(err, operator);
     });
 
-    if(self.closed){
+    if (self.closed) {
         return this._handleClose();
     }
 
-    rpcRequest.on('timeout', function(){
+    rpcRequest.on('timeout', function () {
         delete self.requests[rpcRequest.id];
     });
 
@@ -263,7 +264,7 @@ Connection.prototype.call = function(entry){
  * Send request
  * @param request
  */
-Connection.prototype.sendRequest = function(request){
+Connection.prototype.sendRequest = function (request) {
     let transport = new this.transport();
     let protocol = new this.protocol(transport);
 
@@ -280,7 +281,7 @@ Connection.prototype.sendRequest = function(request){
  * Write data to socket
  * @param msg
  */
-Connection.prototype.send = function(msg){
+Connection.prototype.send = function (msg) {
     this.out.write(msg);
 };
 
@@ -289,7 +290,7 @@ Connection.prototype.send = function(msg){
  * @param out
  * @constructor
  */
-function DataOutputStream(out){
+function DataOutputStream(out) {
     this.out = out;
     this.written = 0;
 }
@@ -298,7 +299,7 @@ function DataOutputStream(out){
  * Write data into stream
  * @param buffer
  */
-DataOutputStream.prototype.write = function(buffer){
+DataOutputStream.prototype.write = function (buffer) {
     this.out.write(buffer);
     this.written += buffer.length;
 };
@@ -324,19 +325,20 @@ function Request(connection, seqid, entry, timeout) {
     this.startTime = Date.now();
     this.timeout = timeout;
 
-    if(timeout && timeout > 0){
+    if (timeout && timeout > 0) {
         log.debug('%s-request%d, timeout %d', this.connection.name, this.id, this.timeout);
         this.timer = setTimeout(this.handleTimeout.bind(this), parseInt(timeout));
     }
 }
+
 util.inherits(Request, EventEmitter);
 
 /**
  * Handle request timeout
  */
-Request.prototype.handleTimeout = function(){
-    let msg = this.connection.name + ' request#' + this.id + ' timeout, use ' + (Date.now()-this.startTime) + 'ms';
-    this.entry.operator.rpc_error = new ErrorCode({'errno' : 'ERR_TIMEOUT'});
+Request.prototype.handleTimeout = function () {
+    let msg = this.connection.name + ' request#' + this.id + ' timeout, use ' + (Date.now() - this.startTime) + 'ms';
+    this.entry.operator.rpc_error = new ErrorCode({'errno': 'ERR_TIMEOUT'});
     log.info('%s has %d requests now', this.connection.name, Object.keys(this.connection.requests).length);
 
     let err = new Exception.RPCException('ERR_TIMEOUT', msg);
@@ -348,13 +350,13 @@ Request.prototype.handleTimeout = function(){
  * Set request exception
  * @param err
  */
-Request.prototype.setException = function(err){
-    if(err.message.indexOf('no error') < 0) {
+Request.prototype.setException = function (err) {
+    if (err.message.indexOf('no error') < 0) {
         log.error('%s request#%d error %s', this.connection.name, this.id, err.message);
     }
     this.error = err;
-    if(err.err_type === 'ERR_SESSION_RESET'){
-        this.entry.operator.rpc_error = new ErrorCode({'errno' : 'ERR_SESSION_RESET'});
+    if (err.err_type === 'ERR_SESSION_RESET') {
+        this.entry.operator.rpc_error = new ErrorCode({'errno': 'ERR_SESSION_RESET'});
     }
     this.callComplete();
 };
@@ -362,18 +364,18 @@ Request.prototype.setException = function(err){
 /**
  * Set request completed
  */
-Request.prototype.callComplete = function(){
-    if(this.timer){
+Request.prototype.callComplete = function () {
+    if (this.timer) {
         clearTimeout(this.timer);
         this.timer = null;
     }
     //Done before
-    if(this.done){
+    if (this.done) {
         return;
     }
     this.done = true;
 
-    let usedTime = Date.now()-this.startTime;
+    let usedTime = Date.now() - this.startTime;
     this.entry.operator.timeout -= usedTime;
     log.debug('%s-request#%d use %dms, remain timeout %dms',
         this.connection.name,
@@ -387,7 +389,7 @@ Request.prototype.callComplete = function(){
  * Set response
  * @param response
  */
-Request.prototype.setResponse = function(response){
+Request.prototype.setResponse = function (response) {
     this.entry.operator.response = response;
     this.callComplete();
 };

--- a/src/errors.js
+++ b/src/errors.js
@@ -8,66 +8,71 @@ const util = require('util');
 const ErrorType = require('./dsn/base_types').error_type;
 
 //Base Error
-function PException(msg){
+function PException(msg) {
     this.message = msg || 'Error';
 }
+
 util.inherits(PException, Error);
 
 //IOException
-function IOException(msg){
+function IOException(msg) {
     IOException.super_.call(this, msg, this.constructor);
     this.name = 'IOException';
 }
+
 util.inherits(IOException, PException);
 
 //InvalidParamException
-function InvalidParamException(msg){
+function InvalidParamException(msg) {
     InvalidParamException.super_.call(this, msg, this.constructor);
     this.name = 'InvalidParamException';
 }
+
 util.inherits(InvalidParamException, PException);
 
 //RPCException
-function RPCException(err_type, msg){
+function RPCException(err_type, msg) {
     RPCException.super_.call(this, msg, this.constructor);
     this.name = 'RPCException';
     this.err_type = err_type;
     this.err_code = ErrorType[this.err_type];
 }
+
 util.inherits(RPCException, IOException);
 
 //MetaException
-function MetaException(err_type, msg){
+function MetaException(err_type, msg) {
     MetaException.super_.call(this, msg, this.constructor);
     this.name = 'MetaException';
     this.err_type = err_type;
     this.err_code = ErrorType[this.err_type];
 }
+
 util.inherits(MetaException, IOException);
 
 let RocksDBErrorCode = {
-    'kOk' : 0,
-    'kNotFound' : 1,
-    'kCorruption' : 2,
-    'kNotSupported' : 3,
-    'kInvalidArgument' : 4,
-    'kIOError' : 5,
-    'kMergeInProgress' : 6,
-    'kIncomplete' : 7,
-    'kShutdownInProgress' : 8,
-    'kTimedOut' : 9,
-    'kAborted' : 10,
-    'kBusy' : 11,
-    'kExpired' : 12,
-    'kTryAgain' : 13,
-    'kNoNeedOperate' : 101,
+    'kOk': 0,
+    'kNotFound': 1,
+    'kCorruption': 2,
+    'kNotSupported': 3,
+    'kInvalidArgument': 4,
+    'kIOError': 5,
+    'kMergeInProgress': 6,
+    'kIncomplete': 7,
+    'kShutdownInProgress': 8,
+    'kTimedOut': 9,
+    'kAborted': 10,
+    'kBusy': 11,
+    'kExpired': 12,
+    'kTryAgain': 13,
+    'kNoNeedOperate': 101,
 };
 
 //RocksDBException
-function RocksDBException(err_code, msg){
+function RocksDBException(err_code, msg) {
     let key, value;
-    for(key in RocksDBErrorCode){
-        if(RocksDBErrorCode[key] === err_code){
+    for (key in RocksDBErrorCode) {
+        if (RocksDBErrorCode[key] === err_code) {
             value = key;
             break;
         }
@@ -77,29 +82,32 @@ function RocksDBException(err_code, msg){
     this.name = 'RocksDBException';
     this.err_code = err_code;
 }
+
 util.inherits(RocksDBException, IOException);
 
 //ConnectionClosedException
-function ConnectionClosedException(msg){
+function ConnectionClosedException(msg) {
     ConnectionClosedException.super_.call(this, msg, this.constructor);
     this.name = 'ConnectionClosedException';
 }
+
 util.inherits(ConnectionClosedException, IOException);
 
 //ThriftException
-function ThriftException(msg){
+function ThriftException(msg) {
     ThriftException.super_.call(this, msg, this.constructor);
     this.name = 'ThriftException';
 }
+
 util.inherits(ThriftException, IOException);
 
 module.exports = {
-    PException : PException,
-    IOException : IOException,
-    InvalidParamException : InvalidParamException,
-    RPCException : RPCException,
-    MetaException : MetaException,
-    RocksDBException : RocksDBException,
-    ConnectionClosedException : ConnectionClosedException,
+    PException: PException,
+    IOException: IOException,
+    InvalidParamException: InvalidParamException,
+    RPCException: RPCException,
+    MetaException: MetaException,
+    RocksDBException: RocksDBException,
+    ConnectionClosedException: ConnectionClosedException,
 };
 

--- a/src/operator.js
+++ b/src/operator.js
@@ -6,12 +6,10 @@
 
 const type = require('./dsn/base_types');
 const tools = require('./tools');
-//const Buffer = require('buffer');
 const Int64 = require('node-int64');
 
 const meta = require('./dsn/meta');
 const rrdb = require('./dsn/rrdb');
-//const replica = require('../dsn/replication_types');
 
 const util = require('util');
 const thrift = require('thrift');
@@ -120,7 +118,6 @@ QueryCfgOperator.prototype.recv_data = function (protocol) {
     if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
     } else {
-        //TODO: Thrift error check
         console.error("Fail to receive result while query config from meta.");
     }
 };
@@ -169,7 +166,6 @@ RrdbGetOperator.prototype.recv_data = function (protocol) {
     if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
     } else {
-        //todo : check
         console.error('Fail to receive result while get data');
     }
 };
@@ -238,7 +234,6 @@ RrdbPutOperator.prototype.recv_data = function (protocol) {
     if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
     } else {
-        //todo: check
         console.error('Fail to receive result while set data');
     }
 };
@@ -299,7 +294,6 @@ RrdbRemoveOperator.prototype.recv_data = function (protocol) {
     if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
     } else {
-        //todo: check
         console.error('Fail to receive result while set data');
     }
 };
@@ -363,7 +357,6 @@ RrdbMultiGetOperator.prototype.recv_data = function (protocol) {
     if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
     } else {
-        //todo: check
         console.error('Fail to receive result while set data');
     }
 };
@@ -434,7 +427,6 @@ RrdbMultiPutOperator.prototype.recv_data = function (protocol) {
     if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
     } else {
-        //todo: check
         console.error('Fail to receive result while set data');
     }
 };

--- a/src/operator.js
+++ b/src/operator.js
@@ -25,7 +25,7 @@ const HEADER_TYPE = 'THFT';
  * @param {gpid}    gpid
  * @constructor
  */
-function ThriftHeader(gpid){
+function ThriftHeader(gpid) {
     this.hdr_version = 0;
     this.header_length = HEADER_LEN;
     this.header_crc32 = 0;
@@ -42,7 +42,7 @@ function ThriftHeader(gpid){
  * Covert header to Buffer
  * @return {Buffer}
  */
-ThriftHeader.prototype.toBuffer = function(){
+ThriftHeader.prototype.toBuffer = function () {
     let buffer = Buffer.alloc(HEADER_LEN - 8);
     buffer.write(HEADER_TYPE, 0);
     buffer.writeInt32BE(this.hdr_version, 4);
@@ -63,7 +63,7 @@ ThriftHeader.prototype.toBuffer = function(){
  * @param {gpid}    gpid
  * @constructor
  */
-function Operator(gpid){
+function Operator(gpid) {
     this.header = new ThriftHeader(gpid);
     this.pid = gpid;
     this.rpc_error = new type.error_code();
@@ -76,7 +76,7 @@ function Operator(gpid){
  * @param  {Number} body_length
  * @return {Buffer}
  */
-Operator.prototype.prepare_thrift_header = function(body_length){
+Operator.prototype.prepare_thrift_header = function (body_length) {
     this.header.body_length = body_length;
     this.header.thread_hash = tools.dsn_gpid_to_thread_hash(this.pid.get_app_id(), this.pid.get_pidx());
     return (this.header.toBuffer());
@@ -90,11 +90,12 @@ Operator.prototype.prepare_thrift_header = function(body_length){
  * @constructor
  * @extends Operator
  */
-function QueryCfgOperator(gpid, request, timeout){
+function QueryCfgOperator(gpid, request, timeout) {
     QueryCfgOperator.super_.call(this, gpid, this.constructor);
     this.request = request;
     this.timeout = timeout;
 }
+
 util.inherits(QueryCfgOperator, Operator);
 
 /**
@@ -102,9 +103,9 @@ util.inherits(QueryCfgOperator, Operator);
  * @param protocol
  * @param seqid
  */
-QueryCfgOperator.prototype.send_data = function(protocol, seqid){
+QueryCfgOperator.prototype.send_data = function (protocol, seqid) {
     protocol.writeMessageBegin('RPC_CM_QUERY_PARTITION_CONFIG_BY_INDEX', thrift.Thrift.MessageType.CALL, seqid);
-    let args = new meta.meta_query_cfg_args({'query' : this.request});
+    let args = new meta.meta_query_cfg_args({'query': this.request});
     args.write(protocol);
     protocol.writeMessageEnd();
 };
@@ -113,12 +114,12 @@ QueryCfgOperator.prototype.send_data = function(protocol, seqid){
  * Receive data
  * @param protocol
  */
-QueryCfgOperator.prototype.recv_data = function(protocol){
+QueryCfgOperator.prototype.recv_data = function (protocol) {
     let result = new meta.meta_query_cfg_result();
     result.read(protocol);
-    if (result.success !== null && result.success !== undefined){
+    if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
-    }else{
+    } else {
         //TODO: Thrift error check
         console.error("Fail to receive result while query config from meta.");
     }
@@ -135,7 +136,7 @@ QueryCfgOperator.prototype.recv_data = function(protocol){
  * @constructor
  * @extends Operator
  */
-function RrdbGetOperator(gpid, request, hashKey, sortKey, timeout, callback){
+function RrdbGetOperator(gpid, request, hashKey, sortKey, timeout, callback) {
     RrdbGetOperator.super_.call(this, gpid, this.constructor);
     this.request = request;
     this.hashKey = hashKey;
@@ -143,6 +144,7 @@ function RrdbGetOperator(gpid, request, hashKey, sortKey, timeout, callback){
     this.timeout = timeout;
     this.userCallback = callback;
 }
+
 util.inherits(RrdbGetOperator, Operator);
 
 /**
@@ -150,9 +152,9 @@ util.inherits(RrdbGetOperator, Operator);
  * @param protocol
  * @param seqid
  */
-RrdbGetOperator.prototype.send_data = function(protocol, seqid){
+RrdbGetOperator.prototype.send_data = function (protocol, seqid) {
     protocol.writeMessageBegin('RPC_RRDB_RRDB_GET', thrift.Thrift.MessageType.CALL, seqid);
-    let args = new rrdb.rrdb_get_args({'key' : this.request});
+    let args = new rrdb.rrdb_get_args({'key': this.request});
     args.write(protocol);
     protocol.writeMessageEnd();
 };
@@ -161,12 +163,12 @@ RrdbGetOperator.prototype.send_data = function(protocol, seqid){
  * Receive data
  * @param protocol
  */
-RrdbGetOperator.prototype.recv_data = function(protocol){
+RrdbGetOperator.prototype.recv_data = function (protocol) {
     let result = new rrdb.rrdb_get_result();
     result.read(protocol);
-    if(result.success !== null && result.success !== undefined){
+    if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
-    }else{
+    } else {
         //todo : check
         console.error('Fail to receive result while get data');
     }
@@ -177,19 +179,19 @@ RrdbGetOperator.prototype.recv_data = function(protocol){
  * @param err
  * @param op
  */
-RrdbGetOperator.prototype.handleResult = function(err, op){
+RrdbGetOperator.prototype.handleResult = function (err, op) {
     let result = op.response;
     // rpc request succeed
-    if(err === null){
-        if(result.error !== 0 && result.error !== 1){
+    if (err === null) {
+        if (result.error !== 0 && result.error !== 1) {
             err = new Exception.RocksDBException(result.error, 'Failed to get result');
             result = null;
-        }else{
+        } else {
             let value = result.value.data;
             result = {
-                'hashKey' : this.hashKey,
-                'sortKey' : this.sortKey,
-                'value' : value,
+                'hashKey': this.hashKey,
+                'sortKey': this.sortKey,
+                'value': value,
             };
         }
     }
@@ -205,12 +207,13 @@ RrdbGetOperator.prototype.handleResult = function(err, op){
  * @param callback
  * @constructor
  */
-function RrdbPutOperator(gpid, request, timeout, callback){
+function RrdbPutOperator(gpid, request, timeout, callback) {
     RrdbPutOperator.super_.call(this, gpid, this.constructor);
     this.request = request;
     this.timeout = timeout;
     this.userCallback = callback;
 }
+
 util.inherits(RrdbPutOperator, Operator);
 
 /**
@@ -218,9 +221,9 @@ util.inherits(RrdbPutOperator, Operator);
  * @param protocol
  * @param seqid
  */
-RrdbPutOperator.prototype.send_data = function(protocol, seqid){
+RrdbPutOperator.prototype.send_data = function (protocol, seqid) {
     protocol.writeMessageBegin('RPC_RRDB_RRDB_PUT', thrift.Thrift.MessageType.CALL, seqid);
-    let args = new rrdb.rrdb_put_args({'update' : this.request});
+    let args = new rrdb.rrdb_put_args({'update': this.request});
     args.write(protocol);
     protocol.writeMessageEnd();
 };
@@ -229,12 +232,12 @@ RrdbPutOperator.prototype.send_data = function(protocol, seqid){
  * Receive data
  * @param protocol
  */
-RrdbPutOperator.prototype.recv_data = function(protocol){
+RrdbPutOperator.prototype.recv_data = function (protocol) {
     let result = new rrdb.rrdb_put_result();
     result.read(protocol);
-    if(result.success !== null && result.success !== undefined){
+    if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
-    }else{
+    } else {
         //todo: check
         console.error('Fail to receive result while set data');
     }
@@ -245,11 +248,11 @@ RrdbPutOperator.prototype.recv_data = function(protocol){
  * @param err
  * @param op
  */
-RrdbPutOperator.prototype.handleResult = function(err, op){
+RrdbPutOperator.prototype.handleResult = function (err, op) {
     let result = op.response;
     // rpc request succeed
-    if(err === null){
-        if(result.error !== 0){
+    if (err === null) {
+        if (result.error !== 0) {
             err = new Exception.RocksDBException(result.error, 'Failed to set result');
             result = null;
         }
@@ -265,12 +268,13 @@ RrdbPutOperator.prototype.handleResult = function(err, op){
  * @param callback
  * @constructor
  */
-function RrdbRemoveOperator(gpid, request, timeout, callback){
+function RrdbRemoveOperator(gpid, request, timeout, callback) {
     RrdbPutOperator.super_.call(this, gpid, this.constructor);
     this.request = request;
     this.timeout = timeout;
     this.userCallback = callback;
 }
+
 util.inherits(RrdbRemoveOperator, Operator);
 
 /**
@@ -278,9 +282,9 @@ util.inherits(RrdbRemoveOperator, Operator);
  * @param protocol
  * @param seqid
  */
-RrdbRemoveOperator.prototype.send_data = function(protocol, seqid){
+RrdbRemoveOperator.prototype.send_data = function (protocol, seqid) {
     protocol.writeMessageBegin('RPC_RRDB_RRDB_REMOVE', thrift.Thrift.MessageType.CALL, seqid);
-    let args = new rrdb.rrdb_remove_args({'key' : this.request});
+    let args = new rrdb.rrdb_remove_args({'key': this.request});
     args.write(protocol);
     protocol.writeMessageEnd();
 };
@@ -289,12 +293,12 @@ RrdbRemoveOperator.prototype.send_data = function(protocol, seqid){
  * Receive data
  * @param protocol
  */
-RrdbRemoveOperator.prototype.recv_data = function(protocol){
+RrdbRemoveOperator.prototype.recv_data = function (protocol) {
     let result = new rrdb.rrdb_remove_result();
     result.read(protocol);
-    if(result.success !== null && result.success !== undefined){
+    if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
-    }else{
+    } else {
         //todo: check
         console.error('Fail to receive result while set data');
     }
@@ -305,11 +309,11 @@ RrdbRemoveOperator.prototype.recv_data = function(protocol){
  * @param err
  * @param op
  */
-RrdbRemoveOperator.prototype.handleResult = function(err, op){
+RrdbRemoveOperator.prototype.handleResult = function (err, op) {
     let result = op.response;
     // rpc request succeed
-    if(err === null){
-        if(result.error !== 0){
+    if (err === null) {
+        if (result.error !== 0) {
             err = new Exception.RocksDBException(result.error, 'Failed to set result');
             result = null;
         }
@@ -327,13 +331,14 @@ RrdbRemoveOperator.prototype.handleResult = function(err, op){
  * @param callback
  * @constructor
  */
-function RrdbMultiGetOperator(gpid, request, hashKey, timeout, callback){
+function RrdbMultiGetOperator(gpid, request, hashKey, timeout, callback) {
     RrdbMultiGetOperator.super_.call(this, gpid, this.constructor);
     this.request = request;
     this.hashKey = hashKey;
     this.timeout = timeout;
     this.userCallback = callback;
 }
+
 util.inherits(RrdbMultiGetOperator, Operator);
 
 /**
@@ -341,9 +346,9 @@ util.inherits(RrdbMultiGetOperator, Operator);
  * @param protocol
  * @param seqid
  */
-RrdbMultiGetOperator.prototype.send_data = function(protocol, seqid){
+RrdbMultiGetOperator.prototype.send_data = function (protocol, seqid) {
     protocol.writeMessageBegin('RPC_RRDB_RRDB_MULTI_GET', thrift.Thrift.MessageType.CALL, seqid);
-    let args = new rrdb.rrdb_multi_get_args({'request' : this.request});
+    let args = new rrdb.rrdb_multi_get_args({'request': this.request});
     args.write(protocol);
     protocol.writeMessageEnd();
 };
@@ -352,12 +357,12 @@ RrdbMultiGetOperator.prototype.send_data = function(protocol, seqid){
  * Receive data
  * @param protocol
  */
-RrdbMultiGetOperator.prototype.recv_data = function(protocol){
+RrdbMultiGetOperator.prototype.recv_data = function (protocol) {
     let result = new rrdb.rrdb_multi_get_result();
     result.read(protocol);
-    if(result.success !== null && result.success !== undefined){
+    if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
-    }else{
+    } else {
         //todo: check
         console.error('Fail to receive result while set data');
     }
@@ -368,20 +373,20 @@ RrdbMultiGetOperator.prototype.recv_data = function(protocol){
  * @param err
  * @param op
  */
-RrdbMultiGetOperator.prototype.handleResult = function(err, op){
+RrdbMultiGetOperator.prototype.handleResult = function (err, op) {
     let result = op.response, data = [];
     // rpc request succeed
-    if(err === null){
-        if(result.error !== 0){
+    if (err === null) {
+        if (result.error !== 0) {
             err = new Exception.RocksDBException(result.error, 'Failed to set result');
             result = null;
-        }else{
+        } else {
             let kvs = result.kvs, len = kvs.length, i;
-            for(i = 0; i < len; ++i){
+            for (i = 0; i < len; ++i) {
                 data.push({
-                    'hashKey' : this.hashKey,
-                    'sortKey' : kvs[i].key.data,
-                    'value'   : kvs[i].value.data,
+                    'hashKey': this.hashKey,
+                    'sortKey': kvs[i].key.data,
+                    'value': kvs[i].value.data,
                 });
             }
         }
@@ -398,12 +403,13 @@ RrdbMultiGetOperator.prototype.handleResult = function(err, op){
  * @param callback
  * @constructor
  */
-function RrdbMultiPutOperator(gpid, request, timeout, callback){
+function RrdbMultiPutOperator(gpid, request, timeout, callback) {
     RrdbMultiPutOperator.super_.call(this, gpid, this.constructor);
     this.request = request;
     this.timeout = timeout;
     this.userCallback = callback;
 }
+
 util.inherits(RrdbMultiPutOperator, Operator);
 
 /**
@@ -411,9 +417,9 @@ util.inherits(RrdbMultiPutOperator, Operator);
  * @param protocol
  * @param seqid
  */
-RrdbMultiPutOperator.prototype.send_data = function(protocol, seqid){
+RrdbMultiPutOperator.prototype.send_data = function (protocol, seqid) {
     protocol.writeMessageBegin('RPC_RRDB_RRDB_MULTI_PUT', thrift.Thrift.MessageType.CALL, seqid);
-    let args = new rrdb.rrdb_multi_put_args({'request' : this.request});
+    let args = new rrdb.rrdb_multi_put_args({'request': this.request});
     args.write(protocol);
     protocol.writeMessageEnd();
 };
@@ -422,12 +428,12 @@ RrdbMultiPutOperator.prototype.send_data = function(protocol, seqid){
  * Receive data
  * @param protocol
  */
-RrdbMultiPutOperator.prototype.recv_data = function(protocol){
+RrdbMultiPutOperator.prototype.recv_data = function (protocol) {
     let result = new rrdb.rrdb_multi_put_result();
     result.read(protocol);
-    if(result.success !== null && result.success !== undefined){
+    if (result.success !== null && result.success !== undefined) {
         this.response = result.success;
-    }else{
+    } else {
         //todo: check
         console.error('Fail to receive result while set data');
     }
@@ -438,11 +444,11 @@ RrdbMultiPutOperator.prototype.recv_data = function(protocol){
  * @param err
  * @param op
  */
-RrdbMultiPutOperator.prototype.handleResult = function(err, op){
+RrdbMultiPutOperator.prototype.handleResult = function (err, op) {
     let result = op.response;
     // rpc request succeed
-    if(err === null){
-        if(result.error !== 0){
+    if (err === null) {
+        if (result.error !== 0) {
             err = new Exception.RocksDBException(result.error, 'Failed to set result');
             result = null;
         }
@@ -451,15 +457,13 @@ RrdbMultiPutOperator.prototype.handleResult = function(err, op){
 };
 
 
-
-
 module.exports = {
-    ThriftHeader : ThriftHeader,
-    Operator : Operator,
-    QueryCfgOperator : QueryCfgOperator,
-    RrdbGetOperator : RrdbGetOperator,
-    RrdbPutOperator : RrdbPutOperator,
-    RrdbRemoveOperator : RrdbRemoveOperator,
-    RrdbMultiGetOperator : RrdbMultiGetOperator,
-    RrdbMultiPutOperator : RrdbMultiPutOperator,
+    ThriftHeader: ThriftHeader,
+    Operator: Operator,
+    QueryCfgOperator: QueryCfgOperator,
+    RrdbGetOperator: RrdbGetOperator,
+    RrdbPutOperator: RrdbPutOperator,
+    RrdbRemoveOperator: RrdbRemoveOperator,
+    RrdbMultiGetOperator: RrdbMultiGetOperator,
+    RrdbMultiPutOperator: RrdbMultiPutOperator,
 };

--- a/src/session.js
+++ b/src/session.js
@@ -85,23 +85,22 @@ Session.prototype.getConnection = function (args, callback) {
         'log': log,
     });
 
-    let sync = true, error = null;
-    connection.once('connectError', function (err) {
-        connection.emit('close');
-        error = err;
-        sync = false;
-    });
-    connection.once('connect', function () {
-        sync = false;
-    });
-    while (sync) {
-        deasync.sleep(1);
-    }
-    if (error === null) {
-        callback(null, connection);
-    } else {
-        callback(error, null);
-    }
+    // let sync = true, error = null;
+    // connection.once('connectError', function(err){
+    //     connection.emit('close');
+    //     error = err;
+    //     sync = false;
+    // });
+    // connection.once('connect', function(){
+    //     sync = false;
+    // });
+    // while(sync){deasync.sleep(1);}
+    // if(error === null){
+    //     callback(null, connection);
+    // }else{
+    //     callback(error, null);
+    // }
+    callback(null, connection);
 };
 
 /**
@@ -131,12 +130,13 @@ function MetaSession(args) {
             self.getConnection({
                 'rpc_address': address,
             }, function (err, connection) {
-                if (err === null && connection !== null) {
-                    self.metaList.push(connection);
-                    log.debug('Finish to get session to meta %s:%s', address.host, address.port);
-                } else {
-                    log.error('Failed to get meta connection, %s', err.message);
-                }
+                self.metaList.push(connection);
+                // if(err === null && connection !== null) {
+                //     self.metaList.push(connection);
+                //     log.debug('Finish to get session to meta %s:%s', address.host, address.port);
+                // }else{
+                //     log.error('Failed to get meta connection, %s', err.message);
+                // }
             });
         } else {
             log.error('invalid meta server address %s', args.metaList[i]);
@@ -280,11 +280,12 @@ function ReplicaSession(args) {
     this.getConnection({
         'rpc_address': addr,
     }, function (err, connection) {
-        if (err === null && connection !== null) {
-            self.connection = connection;
-        } else {
-            log.error('Failed to get replica connection, %s', err.message);
-        }
+        self.connection = connection;
+        // if(err === null && connection !== null) {
+        //     self.connection = connection;
+        // }else{
+        //     log.error('Failed to get replica connection, %s', err.message);
+        // }
     });
 }
 

--- a/src/session.js
+++ b/src/session.js
@@ -255,7 +255,7 @@ MetaSession.prototype.completeQueryMeta = function (err, round) {
  */
 function ReplicaSession(args) {
     ReplicaSession.super_.call(this, args, this.constructor);
-    this.operatorQueue = [];
+    // this.operatorQueue = [];
 
     if (!args || !args.address) {
         log.error('Invalid params, Missing rpc address while creating replica session');
@@ -294,7 +294,7 @@ ReplicaSession.prototype.operate = function (round) {
 //TODO: consider to change event emit
 ReplicaSession.prototype.handleConnectedError = function (tableHandler, address) {
     // 1. get requests in queue
-    let oriConnection = this.connection, needQueryMeta = false;
+    let oriConnection = this.connection; //, needQueryMeta = false;
     // if(requests.length > 0){
     //     for(let id in requests){
     //         let request = requests[id];
@@ -313,31 +313,31 @@ ReplicaSession.prototype.handleConnectedError = function (tableHandler, address)
             self.connection = connection;
             // console.log('%s build!', connection.name);
             // log.info('%s build!', connection.name);
-            self.retryRequests(tableHandler);
+            // self.retryRequests(tableHandler);
             oriConnection.emit('close');
         } else {
             log.error('Failed to get replica connection, %s', err.message);
-            needQueryMeta = true;
+            //needQueryMeta = true;
         }
     });
 
     // 3. retry = false
-    this.retry = false;
-    return needQueryMeta;
+    // this.retry = false;
+    //return needQueryMeta;
 };
 
-ReplicaSession.prototype.retryRequests = function (tableHandler) {
-    let len = this.operatorQueue.length, i;
-    if (len > 0) {
-        log.info('replica session(%s) %d request ready to retry', this.connection.name, len);
-        for (i = 0; i < len; ++i) {   //retry requests
-            let opRetry = this.operatorQueue[i];
-            let clientRoundRetry = new ClientRequestRound(tableHandler, opRetry, opRetry.handleResult.bind(opRetry));
-            this.operate(clientRoundRetry);
-        }
-        this.operatorQueue = [];
-    }
-};
+// ReplicaSession.prototype.retryRequests = function (tableHandler) {
+//     let len = this.operatorQueue.length, i;
+//     if (len > 0) {
+//         log.info('replica session(%s) %d request ready to retry', this.connection.name, len);
+//         for (i = 0; i < len; ++i) {   //retry requests
+//             let opRetry = this.operatorQueue[i];
+//             let clientRoundRetry = new ClientRequestRound(tableHandler, opRetry, opRetry.handleResult.bind(opRetry));
+//             this.operate(clientRoundRetry);
+//         }
+//         this.operatorQueue = [];
+//     }
+// };
 
 
 /**

--- a/src/session.js
+++ b/src/session.js
@@ -10,7 +10,7 @@ const Connection = require('./connection');
 const util = require('util');
 const Exception = require('./errors');
 // const EventEmitter = require('events').EventEmitter;
-const deasync = require('deasync');
+// const deasync = require('deasync');
 const META_DELAY = 500;
 
 let log = null;
@@ -85,6 +85,7 @@ Session.prototype.getConnection = function (args, callback) {
         'log': log,
     });
 
+    // TODO(hyc): delete after whole test
     // let sync = true, error = null;
     // connection.once('connectError', function(err){
     //     connection.emit('close');
@@ -131,6 +132,7 @@ function MetaSession(args) {
                 'rpc_address': address,
             }, function (err, connection) {
                 self.metaList.push(connection);
+                // TODO(hyc): delete after whole test
                 // if(err === null && connection !== null) {
                 //     self.metaList.push(connection);
                 //     log.debug('Finish to get session to meta %s:%s', address.host, address.port);
@@ -162,7 +164,6 @@ MetaSession.prototype.query = function (round) {
             this.onFinishQueryMeta(err, round);
         }.bind(this));
         round.lastConnection.call(entry);
-        //console.log('%s will handle querying meta request', round.lastConnection.name);
     } else {
         log.error('There is no meta session exist');
     }
@@ -180,8 +181,8 @@ MetaSession.prototype.onFinishQueryMeta = function (err, round) {
 
     round.maxQueryCount--;
     if (round.maxQueryCount === 0) {
-        // round.callback(err, op);
-        // console.log('try query meta exceed, current leader is %d, %s',);
+        //TODO(hyc): consider reach maxQueryCount
+        log.error('query meta exceed maxQueryCount, error is %s', err);
         this.completeQueryMeta(err, round);
         return;
     }
@@ -189,52 +190,38 @@ MetaSession.prototype.onFinishQueryMeta = function (err, round) {
     let rpcErr = op.rpc_error.errno;
     let metaErr = ErrorType.ERR_UNKNOWN;
 
-    // if(ErrorType[rpcErr] !== ErrorType.ERR_OK) {
-    //     console.log(rpcErr);
-    // }
-
-
     if (ErrorType[rpcErr] === ErrorType.ERR_OK) {
         metaErr = op.response.err.errno;
         if (ErrorType[metaErr] === ErrorType.ERR_SERVICE_NOT_ACTIVE) {   //meta server may be not ready, need to retry later
+            log.warn('meta server(%s) is not ready, try to query meta later', round.lastConnection.name);
             needDelay = true;
             needSwitch = false;
         } else if (ErrorType[metaErr] === ErrorType.ERR_FORWARD_TO_OTHERS) {  //current meta server is not leader, need to switch leader
+            log.warn('meta server(%s) is not leader, try to switch meta immediatly', round.lastConnection.name);
             needDelay = false;
             needSwitch = true;
         } else {
-            // round.callback(err, op);
-
+            log.debug('query meta server(%s) succeed', round.lastConnection.name);
             this.completeQueryMeta(err, round);
             return;
         }
     } else if (ErrorType[rpcErr] === ErrorType.ERR_SESSION_RESET || ErrorType[rpcErr] === ErrorType.ERR_TIMEOUT) {
+        log.warn('meta session(%s) not available, rpc error is %s, try to switch meta later', round.lastConnection.name, rpcErr);
         needDelay = true;
         needSwitch = true;
     } else {
-        log.error('Unknown error while query meta, %s', rpcErr);
-        // round.callback(err, op);
+        log.error('Unknown error while query meta(%s), rpc error is %s', round.lastConnection.name, rpcErr);
         this.completeQueryMeta(err, round);
         return;
     }
 
-    log.warn('%s, count %d, error is %s, meta error is %s',
-        round.lastConnection.name,
-        round.maxQueryCount,
-        rpcErr,
-        metaErr);
-
-    // console.log('current leader is %d, connection is %s', this.curLeader, round.lastConnection.name);
-    // log.info('current leader is %d, connection is %s', this.curLeader, round.lastConnection.name);
-
+    // switch leader meta server
     if (needSwitch && this.metaList[this.curLeader] === round.lastConnection) {
         this.curLeader = (this.curLeader + 1) % this.metaList.length;
     }
     round.lastConnection = this.metaList[this.curLeader];
 
-    // console.log('next leader is %d, connection is %s, query count is %d', this.curLeader, round.lastConnection.name, round.maxQueryCount);
-    // log.info('next leader is %d, connection is %s, query count is %d', this.curLeader, round.lastConnection.name, round.maxQueryCount);
-
+    // delay to query meta
     let fun = function () {
         self.query(round);
     };
@@ -250,7 +237,7 @@ MetaSession.prototype.completeQueryMeta = function (err, round) {
     round.callback(err, op);
 
     let len = this.roundQueue.length, i;
-    // console.log('%d requests for querying meta will return', len);
+    log.info('%d requests for querying meta will return', len);
     for (i = 0; i < len; ++i) {
         this.roundQueue[i].callback(err, op);
     }
@@ -281,6 +268,7 @@ function ReplicaSession(args) {
         'rpc_address': addr,
     }, function (err, connection) {
         self.connection = connection;
+        // TODO(hyc): delete after whole test
         // if(err === null && connection !== null) {
         //     self.connection = connection;
         // }else{
@@ -303,7 +291,7 @@ ReplicaSession.prototype.operate = function (round) {
     this.connection.call(entry);
 };
 
-//TODO: testing
+//TODO: consider to change event emit
 ReplicaSession.prototype.handleConnectedError = function (tableHandler, address) {
     // 1. get requests in queue
     let oriConnection = this.connection, needQueryMeta = false;
@@ -341,8 +329,7 @@ ReplicaSession.prototype.handleConnectedError = function (tableHandler, address)
 ReplicaSession.prototype.retryRequests = function (tableHandler) {
     let len = this.operatorQueue.length, i;
     if (len > 0) {
-        // console.log('%d request ready to retry', len);
-        // log.info('%d request ready to retry', len);
+        log.info('replica session(%s) %d request ready to retry', this.connection.name, len);
         for (i = 0; i < len; ++i) {   //retry requests
             let opRetry = this.operatorQueue[i];
             let clientRoundRetry = new ClientRequestRound(tableHandler, opRetry, opRetry.handleResult.bind(opRetry));
@@ -362,90 +349,62 @@ ReplicaSession.prototype.onRpcReply = function (err, round) {
     let needQueryMeta = false;
     let op = round.operator;
 
-    //todo:delete
-    // round.count++;
-    // if(round.count === 1){
-    //     op.rpc_error.errno = 'ERR_TIMEOUT';
-    //     op.timeout = 3;
-    // }
-
     switch (ErrorType[op.rpc_error.errno]) {
-        case ErrorType.ERR_OK:
-            round.callback(err, op);
-            return;
-        case ErrorType.ERR_TIMEOUT:
-            log.warn('Table %s: rpc timeout for gpid(%d, %d), err_code is %s',
-                round.tableHandler.tableName,
-                op.pid.get_app_id(),
-                op.pid.get_pidx(),
-                op.rpc_error.errno);
-            break;
-        case ErrorType.ERR_INVALID_DATA:    // maybe task code is invalid
-            log.error('Table %s: invalid data for gpid(%d, %d), err_code is %s',
-                round.tableHandler.tableName,
-                op.pid.get_app_id(),
-                op.pid.get_pidx(),
-                op.rpc_error.errno);
-            break;
-        // round.callback(new Exception.RPCException('ERR_INVALID_DATA',
-        //     'Failed to query replica server, error is ' + 'ERR_INVALID_DATA'
-        // ), op);
-        // return;
-        case ErrorType.ERR_SESSION_RESET:
-        case ErrorType.ERR_OBJECT_NOT_FOUND: // replica server doesn't serve this gpid
-        case ErrorType.ERR_INVALID_STATE:    // replica server is not primary
-            //console.log(round);
-            //TODO: remove timestamp, hashKey
-            log.warn('Table %s: replica server not serve for gpid(%d, %d), err_code is %s',
-                round.tableHandler.tableName,
-                op.pid.get_app_id(),
-                op.pid.get_pidx(),
-                op.rpc_error.errno);
-            needQueryMeta = true;
-            break;
-        case ErrorType.ERR_NOT_ENOUGH_MEMBER:
-        case ErrorType.ERR_CAPACITY_EXCEEDED:
-            log.warn('Table %s: replica server cannot serve writing for gpid(%d, %d), err_code is %s',
-                round.tableHandler.tableName,
-                op.pid.get_app_id(),
-                op.pid.get_pidx(),
-                op.rpc_error.errno);
-            break;
-        default:
-            log.error('Table %s: unexpected error for gpid(%d, %d), err_code is %s',
-                round.tableHandler.tableName,
-                op.pid.get_app_id(),
-                op.pid.get_pidx(),
-                op.rpc_error.errno);
-            break;
-        // round.callback(new Exception.RPCException(ErrorType[op.rpc_error.errno],
-        //     'Failed to query replica server, error is ' + ErrorType[op.rpc_error.errno]
-        // ), op);
-        // round.callback(err, op);
-        // return;
+    case ErrorType.ERR_OK:
+        round.callback(err, op);
+        return;
+    case ErrorType.ERR_TIMEOUT:
+        log.warn('Table %s: rpc timeout for gpid(%d, %d), err_code is %s',
+            round.tableHandler.tableName,
+            op.pid.get_app_id(),
+            op.pid.get_pidx(),
+            op.rpc_error.errno);
+        break;
+    case ErrorType.ERR_INVALID_DATA:    // maybe task code is invalid
+        log.error('Table %s: invalid data for gpid(%d, %d), err_code is %s',
+            round.tableHandler.tableName,
+            op.pid.get_app_id(),
+            op.pid.get_pidx(),
+            op.rpc_error.errno);
+        break;
+    case ErrorType.ERR_SESSION_RESET:
+    case ErrorType.ERR_OBJECT_NOT_FOUND: // replica server doesn't serve this gpid
+    case ErrorType.ERR_INVALID_STATE:    // replica server is not primary
+        log.warn('Table %s: replica server not serve for gpid(%d, %d), err_code is %s',
+            round.tableHandler.tableName,
+            op.pid.get_app_id(),
+            op.pid.get_pidx(),
+            op.rpc_error.errno);
+        needQueryMeta = true;
+        break;
+    case ErrorType.ERR_NOT_ENOUGH_MEMBER:
+    case ErrorType.ERR_CAPACITY_EXCEEDED:
+        log.warn('Table %s: replica server cannot serve writing for gpid(%d, %d), err_code is %s',
+            round.tableHandler.tableName,
+            op.pid.get_app_id(),
+            op.pid.get_pidx(),
+            op.rpc_error.errno);
+        break;
+    default:
+        log.error('Table %s: unexpected error for gpid(%d, %d), err_code is %s',
+            round.tableHandler.tableName,
+            op.pid.get_app_id(),
+            op.pid.get_pidx(),
+            op.rpc_error.errno);
+        break;
     }
 
     if (needQueryMeta) {
-        round.tableHandler.callback = function (err) {
-            if (err !== null) {
-                //let hashKey = op.hashKey || new Buffer('');
-                // console.log(hashKey);
-                // console.log(err);
-                //round.callback(err, op);
-            }
+        round.tableHandler.callback = function (err, handler) {
+            // do nothing
+            // TODO(hyc): delete after whole test
+            // if (err !== null) {
+            // }
         }.bind(this);
         round.tableHandler.queryMeta(round.tableHandler.tableName, round.tableHandler.onUpdateResponse.bind(round.tableHandler));
     }
 
     this.tryRetry(err, round);
-    // if(op.timeout > 0) {
-    //     this.operate(round);
-    // }else{
-    //     let err_type = 'ERR_TIMEOUT';
-    //     round.callback(new Exception.RPCException(err_type,
-    //         'Failed to query server, error is ' + err_type
-    //     ), op);
-    // }
 };
 
 ReplicaSession.prototype.tryRetry = function (err, round) {
@@ -453,8 +412,6 @@ ReplicaSession.prototype.tryRetry = function (err, round) {
     let self = this;
     let delayTime = op.timeout > 3 ? op.timeout / 3 : 1;
     if (op.timeout - delayTime > 0) {
-        //console.log('hashKey %s will retry after %dms, error_code is %s', op.hashKey, delayTime, op.rpc_error.errno);
-        //console.log('hashKey %s current timeout is %dms, should be set %dms', op.hashKey, op.timeout, op.timeout-delayTime);
         op.timeout -= delayTime;
         round.operator = op;
         setTimeout(function () {
@@ -464,11 +421,7 @@ ReplicaSession.prototype.tryRetry = function (err, round) {
         if (ErrorType[op.rpc_error.errno] === ErrorType.ERR_UNKNOWN) {
             op.rpc_error.errno = ErrorType.ERR_TIMEOUT;
             round.callback(new Exception.RPCException('ERR_TIMEOUT', err.message), op);
-        }
-        // else{
-        //     round.callback(err, op);
-        // }
-        else {
+        } else {
             round.callback(new Exception.RPCException(op.rpc_error.errno, 'Failed to query server, error is ' + op.rpc_error.errno), op);
         }
     }

--- a/src/table_handler.js
+++ b/src/table_handler.js
@@ -156,19 +156,33 @@ TableHandler.prototype.operate = function (gpid, op) {
     }
 
     //TODO(hyc): how to handle timeout session's requests
-    if (session.retry) { // others are reconnecting this session
-        session.operatorQueue.push(op);
-    } else if (session.connection.connectError) { // connection has connected error
-        session.retry = true;
-        session.operatorQueue.push(op);
-        if (session.handleConnectedError(this, address)) {
-            this.queryMeta(this.tableName, this.onUpdateResponse.bind(this));
-        }
-    } else {
-        // connection is normal
-        let clientRound = new ClientRequestRound(this, op, op.handleResult.bind(op));
-        session.operate(clientRound);
+    // if (session.retry) { // others are reconnecting this session
+    //     session.operatorQueue.push(op);
+    // } else if (session.connection.connectError) { // connection has connected error
+    //     session.retry = true;
+    //     session.operatorQueue.push(op);
+    //     if (session.handleConnectedError(this, address)) {
+    //         this.queryMeta(this.tableName, this.onUpdateResponse.bind(this));
+    //     }
+    // } else {
+    //     // connection is normal
+    //     let clientRound = new ClientRequestRound(this, op, op.handleResult.bind(op));
+    //     session.operate(clientRound);
+    // }
+
+    if (session.connection.connectError) { // connection has connected error
+        // session.retry = true;
+        // session.operatorQueue.push(op);
+        // if (session.handleConnectedError(this, address)) {
+        //     this.queryMeta(this.tableName, this.onUpdateResponse.bind(this));
+        // }
+        session.handleConnectedError(this, address);
     }
+    //else {
+    // connection is normal
+    let clientRound = new ClientRequestRound(this, op, op.handleResult.bind(op));
+    session.operate(clientRound);
+    //}
 };
 
 /**

--- a/src/table_handler.js
+++ b/src/table_handler.js
@@ -16,7 +16,7 @@ const ClientRequestRound = require('./session').ClientRequestRound;
 const Operator = require('./operator');
 const Long = require('long');
 const tools = require('./tools');
-const deasync = require('deasync');
+// const deasync = require('deasync');
 
 const DEFAULT_MULTI_COUNT = 100;
 const DEFAULT_MULTI_SIZE = 1000000;
@@ -73,7 +73,6 @@ TableHandler.prototype.queryMeta = function (tableName, callback) {
         //console.log('table %s is querying meta', tableName);
         session.query(round);
     }
-    // session.query(round);
 };
 
 /**
@@ -122,11 +121,16 @@ TableHandler.prototype.updateResponse = function (oldResp, newResp) {
         let session = tools.findSessionByAddr(current_sessions, primary_addr);
         if (session === null) {
             session = new ReplicaSession({'address': primary_addr});
+            this.cluster.replicaSessions.push({
+                'key': primary_addr,
+                'value': session,
+            });
         }
-        this.cluster.replicaSessions.push({
-            'key': primary_addr,
-            'value': session,
-        });
+        // TODO(hyc): delete after whole test
+        // this.cluster.replicaSessions.push({
+        //     'key': primary_addr,
+        //     'value': session,
+        // });
         connected_rpc.push(primary_addr);
     }
     this.queryCfgResponse = newResp;
@@ -246,29 +250,29 @@ TableInfo.prototype.get = function (args, callback) {
  *        {Number}      argsArray[i].timeout(ms)
  * @param {Function}    callback
  */
-TableInfo.prototype.batchGet = function (argsArray, callback) {
-    let i, len = argsArray.length;
-    let error = null, resultArray = [], sync = true;
-
-    for (i = 0; i < len; ++i) {
-        let args = argsArray[i];
-        this.get(args, function (err, result) {
-            if (err !== null) {
-                error = err;
-                sync = false;
-            } else {
-                resultArray.push(result);
-            }
-            if (resultArray.length === len) {
-                sync = false;
-            }
-        });
-    }
-    while (sync) {
-        deasync.sleep(1);
-    }
-    callback(error, resultArray);
-};
+// TableInfo.prototype.batchGet = function (argsArray, callback) {
+//     let i, len = argsArray.length;
+//     let error = null, resultArray = [], sync = true;
+//
+//     for (i = 0; i < len; ++i) {
+//         let args = argsArray[i];
+//         this.get(args, function (err, result) {
+//             if (err !== null) {
+//                 error = err;
+//                 sync = false;
+//             } else {
+//                 resultArray.push(result);
+//             }
+//             if (resultArray.length === len) {
+//                 sync = false;
+//             }
+//         });
+//     }
+//     while (sync) {
+//         deasync.sleep(1);
+//     }
+//     callback(error, resultArray);
+// };
 
 /**
  * Batch Get value using promise
@@ -347,29 +351,29 @@ TableInfo.prototype.set = function (args, callback) {
  *        {Number}      argsArray[i].timeout(ms)
  * @param {Function}    callback
  */
-TableInfo.prototype.batchSet = function (argsArray, callback) {
-    let i, len = argsArray.length;
-    let error = null, resultArray = [], sync = true;
-
-    for (i = 0; i < len; ++i) {
-        let args = argsArray[i];
-        this.set(args, function (err, result) {
-            if (err !== null) {
-                error = err;
-                sync = false;
-            } else {
-                resultArray.push(result);
-            }
-            if (resultArray.length === len) {
-                sync = false;
-            }
-        });
-    }
-    while (sync) {
-        deasync.sleep(1);
-    }
-    callback(error, resultArray);
-};
+// TableInfo.prototype.batchSet = function (argsArray, callback) {
+//     let i, len = argsArray.length;
+//     let error = null, resultArray = [], sync = true;
+//
+//     for (i = 0; i < len; ++i) {
+//         let args = argsArray[i];
+//         this.set(args, function (err, result) {
+//             if (err !== null) {
+//                 error = err;
+//                 sync = false;
+//             } else {
+//                 resultArray.push(result);
+//             }
+//             if (resultArray.length === len) {
+//                 sync = false;
+//             }
+//         });
+//     }
+//     while (sync) {
+//         deasync.sleep(1);
+//     }
+//     callback(error, resultArray);
+// };
 
 /**
  * Batch Set value using promise

--- a/src/table_handler.js
+++ b/src/table_handler.js
@@ -29,7 +29,7 @@ let log = null;
  * @param   {Function}  callback
  * @constructor
  */
-function TableHandler(cluster, tableName, callback){
+function TableHandler(cluster, tableName, callback) {
     log = cluster.log;
     this.cluster = cluster;
     this.tableName = tableName;
@@ -41,10 +41,10 @@ function TableHandler(cluster, tableName, callback){
     this.partition_count = 0;
     this.partitions = {};       //partition pid -> primary rpc_address
 
-    if(this.cluster.metaSession.connectionError){
+    if (this.cluster.metaSession.connectionError) {
         //Failed to get meta sessions
         callback(this.cluster.metaSession.connectionError, null);
-    }else {
+    } else {
         this.queryMeta(tableName, this.onUpdateResponse.bind(this));
     }
 }
@@ -54,7 +54,7 @@ function TableHandler(cluster, tableName, callback){
  * @param {String}      tableName
  * @param {Function}    callback
  */
-TableHandler.prototype.queryMeta = function(tableName, callback){
+TableHandler.prototype.queryMeta = function (tableName, callback) {
     let session = this.cluster.metaSession;
     let queryCfgOperator = new Operator.QueryCfgOperator(new Gpid(-1, -1),
         new replica.query_cfg_request({'app_name': tableName}),
@@ -64,11 +64,11 @@ TableHandler.prototype.queryMeta = function(tableName, callback){
         session.maxRetryCounter,
         session.metaList[session.curLeader]);
 
-    if(session.isQuery){
+    if (session.isQuery) {
         session.roundQueue.push(round);
         // log.info('%d requests is waiting', session.roundQueue.length);
         // console.log('%d requests is waiting', session.roundQueue.length);
-    }else{
+    } else {
         session.isQuery = true;
         //console.log('table %s is querying meta', tableName);
         session.query(round);
@@ -81,17 +81,17 @@ TableHandler.prototype.queryMeta = function(tableName, callback){
  * @param {Error}       err
  * @param {Operator}    op
  */
-TableHandler.prototype.onUpdateResponse = function(err, op){
+TableHandler.prototype.onUpdateResponse = function (err, op) {
     let response = op.response;
 
-    if(err === null && ErrorType[response.err.errno] === ErrorType.ERR_OK){
+    if (err === null && ErrorType[response.err.errno] === ErrorType.ERR_OK) {
         this.updateResponse(this.queryCfgResponse, response);
         this.callback(null, this);
-    }else if(err === null){
+    } else if (err === null) {
         this.callback(new Exception.MetaException(
             response.err.errno, 'Failed to query meta server, error is ' + response.err.errno
         ), null);
-    }else{
+    } else {
         this.callback(err, null);
     }
 };
@@ -101,7 +101,7 @@ TableHandler.prototype.onUpdateResponse = function(err, op){
  * @param   oldResp
  * @param   newResp
  */
-TableHandler.prototype.updateResponse = function(oldResp, newResp){
+TableHandler.prototype.updateResponse = function (oldResp, newResp) {
     this.app_id = newResp.app_id;
     this.partition_count = newResp.partition_count;
 
@@ -111,21 +111,21 @@ TableHandler.prototype.updateResponse = function(oldResp, newResp){
     let connected_rpc = [];
 
     let i, len = newResp.partitions.length;
-    for(i = 0; i < len; ++i){
+    for (i = 0; i < len; ++i) {
         let partition = newResp.partitions[i];
         let primary_addr = partition.primary;
         this.partitions[partition.pid.get_pidx()] = primary_addr;
 
-        if(tools.isAddrExist(connected_rpc, primary_addr) === true){
+        if (tools.isAddrExist(connected_rpc, primary_addr) === true) {
             continue;
         }
         let session = tools.findSessionByAddr(current_sessions, primary_addr);
-        if(session === null){
-            session  = new ReplicaSession({'address':primary_addr});
+        if (session === null) {
+            session = new ReplicaSession({'address': primary_addr});
         }
         this.cluster.replicaSessions.push({
-            'key' : primary_addr,
-            'value' : session,
+            'key': primary_addr,
+            'value': session,
         });
         connected_rpc.push(primary_addr);
     }
@@ -138,31 +138,31 @@ TableHandler.prototype.updateResponse = function(oldResp, newResp){
  * @param {Operator}   op
  */
 //TODO: testing
-TableHandler.prototype.operate = function(gpid, op){
+TableHandler.prototype.operate = function (gpid, op) {
     let pidx = gpid.get_pidx();
     let address = this.partitions[pidx];
     let session = tools.findSessionByAddr(this.cluster.replicaSessions, address);
     //let self = this;
 
-    if(session === null || session === undefined){ //TODO: check when to meet this situation
+    if (session === null || session === undefined) { //TODO: check when to meet this situation
         log.error('Replica session not exist');
         return;
     }
 
     //let hashKey = op.hashKey;
-    if(session.retry){ // others are reconnecting this session
+    if (session.retry) { // others are reconnecting this session
         // console.log('%s is waiting', hashKey);
         // log.info('%s is waiting', hashKey);
         session.operatorQueue.push(op);
-    }else if(session.connection.connectError){ // connection has connected error
+    } else if (session.connection.connectError) { // connection has connected error
         // console.log('%s is retrying', hashKey);
         // log.info('%s is retrying', hashKey);
         session.retry = true;
         session.operatorQueue.push(op);
-        if(session.handleConnectedError(this, address)){
+        if (session.handleConnectedError(this, address)) {
             this.queryMeta(this.tableName, this.onUpdateResponse.bind(this));
         }
-    }else {
+    } else {
         // connection is normal
         let clientRound = new ClientRequestRound(this, op, op.handleResult.bind(op));
         session.operate(clientRound);
@@ -176,7 +176,7 @@ TableHandler.prototype.operate = function(gpid, op){
  * @param   {Number}        timeout
  * @constructor
  */
-function TableInfo(client, tableHandler, timeout){
+function TableInfo(client, tableHandler, timeout) {
     this.client = client;
     this.tableHandler = tableHandler;
     this.timeout = timeout;
@@ -187,17 +187,17 @@ function TableInfo(client, tableHandler, timeout){
  * @param  {blob}   blob_key
  * @return {gpid}   gpid
  */
-TableInfo.prototype.getGpid = function(blob_key){
+TableInfo.prototype.getGpid = function (blob_key) {
     let hash_value = this.tableHandler.keyHash.hash(blob_key.data);
     let app_id = this.tableHandler.app_id;
     let pidx = hash_value.mod(this.tableHandler.partition_count).getLowBits();
     //pidx should be greater than zero
-    while(pidx < 0 && pidx < this.tableHandler.partition_count){
+    while (pidx < 0 && pidx < this.tableHandler.partition_count) {
         pidx += this.tableHandler.partition_count;
     }
     return new Gpid({
-        'app_id' : app_id,
-        'pidx' : pidx,
+        'app_id': app_id,
+        'pidx': pidx,
     });
 };
 
@@ -206,17 +206,17 @@ TableInfo.prototype.getGpid = function(blob_key){
  * @param  {Buffer} hash_key
  * @return {gpid}   gpid
  */
-TableInfo.prototype.get_hash_key_pid = function(hash_key){
+TableInfo.prototype.get_hash_key_pid = function (hash_key) {
     let hash_value = this.tableHandler.keyHash.default_hash(hash_key);
     let app_id = this.tableHandler.app_id;
     let pidx = hash_value.mod(this.tableHandler.partition_count).getLowBits();
     //pidx should be greater than zero
-    while(pidx < 0 && pidx < this.tableHandler.partition_count){
+    while (pidx < 0 && pidx < this.tableHandler.partition_count) {
         pidx += this.tableHandler.partition_count;
     }
     return new Gpid({
-        'app_id' : app_id,
-        'pidx' : pidx,
+        'app_id': app_id,
+        'pidx': pidx,
     });
 };
 
@@ -228,7 +228,7 @@ TableInfo.prototype.get_hash_key_pid = function(hash_key){
  *        {Number}      args.timeout
  * @param {Function}    callback
  */
-TableInfo.prototype.get = function(args, callback){
+TableInfo.prototype.get = function (args, callback) {
     let timeout = args.timeout || this.timeout;
     let request = new Blob({
         'data': tools.generateKey(args.hashKey, args.sortKey),
@@ -246,25 +246,27 @@ TableInfo.prototype.get = function(args, callback){
  *        {Number}      argsArray[i].timeout(ms)
  * @param {Function}    callback
  */
-TableInfo.prototype.batchGet = function(argsArray, callback){
+TableInfo.prototype.batchGet = function (argsArray, callback) {
     let i, len = argsArray.length;
     let error = null, resultArray = [], sync = true;
 
-    for(i = 0; i < len; ++i){
+    for (i = 0; i < len; ++i) {
         let args = argsArray[i];
-        this.get(args, function(err, result){
-            if(err !== null){
+        this.get(args, function (err, result) {
+            if (err !== null) {
                 error = err;
-                sync =false;
-            }else{
+                sync = false;
+            } else {
                 resultArray.push(result);
             }
-            if(resultArray.length === len){
-                sync =false;
+            if (resultArray.length === len) {
+                sync = false;
             }
         });
     }
-    while(sync){deasync.sleep(1);}
+    while (sync) {
+        deasync.sleep(1);
+    }
     callback(error, resultArray);
 };
 
@@ -276,14 +278,14 @@ TableInfo.prototype.batchGet = function(argsArray, callback){
  *        {Number}      argsArray[i].timeout(ms)
  * @param {Function}    callback
  */
-TableInfo.prototype.batchGetPromise = function(argsArray, callback){
+TableInfo.prototype.batchGetPromise = function (argsArray, callback) {
     let tasks = [], i, len = argsArray.length, self = this;
-    for(i = 0; i < len; ++i){
-        tasks.push(new Promise(function(resolve){
+    for (i = 0; i < len; ++i) {
+        tasks.push(new Promise(function (resolve) {
 
             // let start = Date.now();
             // let hashKey = argsArray[i].hashKey;
-            self.get(argsArray[i], function(err, result){
+            self.get(argsArray[i], function (err, result) {
                 // if(err === null){
                 //     console.log('hashKey %s use time %s~%s, %dms', hashKey, start, Date.now(), Date.now()-start);
                 //     // log.info('hashKey %s use time %s~%s, %dms', hashKey, start, Date.now(), Date.now()-start);
@@ -293,11 +295,11 @@ TableInfo.prototype.batchGetPromise = function(argsArray, callback){
                 //     // log.info('hashKey %s', hashKey);
                 //     // log.error('error name is %s, type is %s, message is %s', err.name, err.err_type, err.message);
                 // }
-                resolve({'error' : err, 'data' : result});
+                resolve({'error': err, 'data': result});
             });
         }));
     }
-    Promise.all(tasks).then(function(values){
+    Promise.all(tasks).then(function (values) {
         callback(null, values);
     });
 };
@@ -313,24 +315,24 @@ TableInfo.prototype.batchGetPromise = function(argsArray, callback){
  *        {Number}      args.timeout
  * @param {Function}    callback
  */
-TableInfo.prototype.set = function(args, callback){
+TableInfo.prototype.set = function (args, callback) {
     //set ttl
-    if(!args.ttl || typeof(args.ttl) !== 'number' || args.ttl < 0){
+    if (!args.ttl || typeof(args.ttl) !== 'number' || args.ttl < 0) {
         args.ttl = 0;
     }
     let timeout = args.timeout || this.timeout;
     let key = new Blob({
-        'data' : tools.generateKey(args.hashKey, args.sortKey),
+        'data': tools.generateKey(args.hashKey, args.sortKey),
     });
     let blob_value = new Blob({
-        'data' : args.value,
+        'data': args.value,
     });
 
     let gpid = this.getGpid(key);
     let op = new Operator.RrdbPutOperator(gpid, new RrdbType.update_request({
-        'key' : key,
-        'value' : blob_value,
-        'expire_ts_seconds' : args.ttl,
+        'key': key,
+        'value': blob_value,
+        'expire_ts_seconds': args.ttl,
     }), timeout, callback);
     this.tableHandler.operate(gpid, op);
 };
@@ -345,25 +347,27 @@ TableInfo.prototype.set = function(args, callback){
  *        {Number}      argsArray[i].timeout(ms)
  * @param {Function}    callback
  */
-TableInfo.prototype.batchSet = function(argsArray, callback){
+TableInfo.prototype.batchSet = function (argsArray, callback) {
     let i, len = argsArray.length;
     let error = null, resultArray = [], sync = true;
 
-    for(i = 0; i < len; ++i){
+    for (i = 0; i < len; ++i) {
         let args = argsArray[i];
-        this.set(args, function(err, result){
-            if(err !== null){
+        this.set(args, function (err, result) {
+            if (err !== null) {
                 error = err;
-                sync =false;
-            }else{
+                sync = false;
+            } else {
                 resultArray.push(result);
             }
-            if(resultArray.length === len){
-                sync =false;
+            if (resultArray.length === len) {
+                sync = false;
             }
         });
     }
-    while(sync){deasync.sleep(1);}
+    while (sync) {
+        deasync.sleep(1);
+    }
     callback(error, resultArray);
 };
 
@@ -377,16 +381,16 @@ TableInfo.prototype.batchSet = function(argsArray, callback){
  *        {Number}      argsArray[i].timeout(ms)
  * @param {Function}    callback
  */
-TableInfo.prototype.batchSetPromise = function(argsArray, callback){
+TableInfo.prototype.batchSetPromise = function (argsArray, callback) {
     let tasks = [], i, len = argsArray.length, self = this;
-    for(i = 0; i < len; ++i){
-        tasks.push(new Promise(function(resolve){
-            self.set(argsArray[i], function(err, result){
-                resolve({'error' : err, 'data' : result});
+    for (i = 0; i < len; ++i) {
+        tasks.push(new Promise(function (resolve) {
+            self.set(argsArray[i], function (err, result) {
+                resolve({'error': err, 'data': result});
             });
         }));
     }
-    Promise.all(tasks).then(function(values){
+    Promise.all(tasks).then(function (values) {
         callback(null, values);
     });
 };
@@ -399,7 +403,7 @@ TableInfo.prototype.batchSetPromise = function(argsArray, callback){
  *        {Number}      args.timeout
  * @param {Function}    callback
  */
-TableInfo.prototype.del = function(args, callback){
+TableInfo.prototype.del = function (args, callback) {
     let timeout = args.timeout || this.timeout;
     let request = new Blob({
         'data': tools.generateKey(args.hashKey, args.sortKey),
@@ -420,7 +424,7 @@ TableInfo.prototype.del = function(args, callback){
  *        {Number}      args.maxFetchSize
  * @param {Function}    callback
  */
-TableInfo.prototype.multiGet = function(args, callback){
+TableInfo.prototype.multiGet = function (args, callback) {
     let timeout = args.timeout || this.timeout,
         maxFetchCount = args.maxFetchCount || DEFAULT_MULTI_COUNT,
         maxFetchSize = args.maxFetchSize || DEFAULT_MULTI_SIZE,
@@ -429,20 +433,20 @@ TableInfo.prototype.multiGet = function(args, callback){
     let gpid = this.get_hash_key_pid(args.hashKey);
 
     let hashKeyBlob = new Blob({
-        'data' : args.hashKey,
+        'data': args.hashKey,
     });
     let i, len = args.sortKeyArray.length, sortKeyBlobs = [];
-    for(i = 0; i < len; ++i){
+    for (i = 0; i < len; ++i) {
         sortKeyBlobs[i] = new Blob({
-            'data' : args.sortKeyArray[i],
+            'data': args.sortKeyArray[i],
         });
     }
     let request = new RrdbType.multi_get_request({
-        'hash_key' : hashKeyBlob,
-        'sork_keys' : sortKeyBlobs,
-        'max_kv_count' : maxFetchCount,
-        'max_kv_size' : maxFetchSize,
-        'no_value' : no_value
+        'hash_key': hashKeyBlob,
+        'sork_keys': sortKeyBlobs,
+        'max_kv_count': maxFetchCount,
+        'max_kv_size': maxFetchSize,
+        'no_value': no_value
     });
     let op = new Operator.RrdbMultiGetOperator(gpid, request, args.hashKey, timeout, callback);
     this.tableHandler.operate(gpid, op);
@@ -458,28 +462,28 @@ TableInfo.prototype.multiGet = function(args, callback){
  *        {Number}      args.ttl(s)
  * @param {Function}    callback
  */
-TableInfo.prototype.multiSet = function(args, callback){
-    if(!args.ttl || typeof(args.ttl) !== 'number' || args.ttl < 0){
+TableInfo.prototype.multiSet = function (args, callback) {
+    if (!args.ttl || typeof(args.ttl) !== 'number' || args.ttl < 0) {
         args.ttl = 0;
     }
     let timeout = args.timeout || this.timeout,
         gpid = this.get_hash_key_pid(args.hashKey);
 
     let hashKeyBlob = new Blob({
-        'data' : args.hashKey,
+        'data': args.hashKey,
     });
     let i, len = args.sortKeyValueArray.length, valueBlobs = [];
-    for(i = 0; i < len; ++i){
+    for (i = 0; i < len; ++i) {
         valueBlobs[i] = new RrdbType.key_value({
-            'key' : new Blob({'data' : args.sortKeyValueArray[i].key}),
-            'value' : new Blob({'data' : args.sortKeyValueArray[i].value}),
+            'key': new Blob({'data': args.sortKeyValueArray[i].key}),
+            'value': new Blob({'data': args.sortKeyValueArray[i].value}),
         });
     }
 
     let request = new RrdbType.multi_put_request({
-        'hash_key' : hashKeyBlob,
-        'kvs' : valueBlobs,
-        'expire_ts_seconds' : args.ttl,
+        'hash_key': hashKeyBlob,
+        'kvs': valueBlobs,
+        'expire_ts_seconds': args.ttl,
     });
 
     let op = new Operator.RrdbMultiPutOperator(gpid, request, timeout, callback);
@@ -490,7 +494,7 @@ TableInfo.prototype.multiSet = function(args, callback){
  * Constructor for helper class for calculating hash value
  * @constructor
  */
-function PegasusHash(){
+function PegasusHash() {
     this.crc64_table = [
         '0x0000000000000000', '0x7f6ef0c830358979', '0xfedde190606b12f2', '0x81b31158505e9b8b',
         '0xc962e5739841b68f', '0xb60c15bba8743ff6', '0x37bf04e3f82aa47d', '0x48d1f42bc81f2d04',
@@ -565,12 +569,12 @@ function PegasusHash(){
  * @param   {Number}    len
  * @return  {Long}      crc64
  */
-PegasusHash.prototype.crc64 = function(buf, offset, len){
+PegasusHash.prototype.crc64 = function (buf, offset, len) {
     let crc = new Long(-1, -1);
     let end = offset + len;
 
     let i;
-    for(i = offset; i < end; ++i){
+    for (i = offset; i < end; ++i) {
         let index = (buf[i] ^ crc.getLowBits()) & 0xFF;
         let other = this.toLong(index);
         crc = crc.shiftRightUnsigned(8).xor(other);
@@ -583,7 +587,7 @@ PegasusHash.prototype.crc64 = function(buf, offset, len){
  * @param   {Number}    index
  * @return  {Long}      result
  */
-PegasusHash.prototype.toLong = function(index){
+PegasusHash.prototype.toLong = function (index) {
     let value = this.crc64_table[index];
     let high = value.slice(2, 10);
     let low = value.slice(10);
@@ -595,21 +599,21 @@ PegasusHash.prototype.toLong = function(index){
  * @param   {Buffer}    blob_key
  * @return  {Long}      hash
  */
-PegasusHash.prototype.hash = function(blob_key){
-    if(!blob_key || blob_key.length < 2){
+PegasusHash.prototype.hash = function (blob_key) {
+    if (!blob_key || blob_key.length < 2) {
         log.error('blob_key is invalid');
         throw new Exception.InvalidParamException('blob_key is invalid');
     }
 
     let hashLen = blob_key.readInt16BE(0);
-    if(hashLen === 0xFFFF || (hashLen+2) > blob_key.length){
+    if (hashLen === 0xFFFF || (hashLen + 2) > blob_key.length) {
         log.error('blob_key hash key length is invalid');
         throw new Exception.InvalidParamException('blob_key is invalid');
     }
 
-    if(hashLen === 0){
-        return this.crc64(blob_key, 2, blob_key.length-2);
-    }else{
+    if (hashLen === 0) {
+        return this.crc64(blob_key, 2, blob_key.length - 2);
+    } else {
         return this.crc64(blob_key, 2, hashLen);
     }
 };
@@ -619,15 +623,15 @@ PegasusHash.prototype.hash = function(blob_key){
  * @param   {Buffer}    hashKey
  * @return  {Long}      crc64
  */
-PegasusHash.prototype.default_hash = function(hashKey){
-    if(!Buffer.isBuffer(hashKey)){
+PegasusHash.prototype.default_hash = function (hashKey) {
+    if (!Buffer.isBuffer(hashKey)) {
         hashKey = new Buffer(hashKey);
     }
     return this.crc64(hashKey, 0, hashKey.length);
 };
 
 module.exports = {
-    TableHandler : TableHandler,
-    TableInfo : TableInfo,
+    TableHandler: TableHandler,
+    TableInfo: TableInfo,
 };
 

--- a/src/tools.js
+++ b/src/tools.js
@@ -13,8 +13,8 @@ const net = require('net');
  * @param {number} partition_index
  * @return {number}
  */
-function dsn_gpid_to_thread_hash(app_id, partition_index){
-    return (parseInt(app_id)*7919 + parseInt(partition_index));
+function dsn_gpid_to_thread_hash(app_id, partition_index) {
+    return (parseInt(app_id) * 7919 + parseInt(partition_index));
 }
 
 /**
@@ -23,11 +23,11 @@ function dsn_gpid_to_thread_hash(app_id, partition_index){
  * @param addr
  * @return {boolean}
  */
-function isAddrExist(array, addr){
+function isAddrExist(array, addr) {
     let i, len = array.length;
     let flag = false;
-    for(i = 0; i < len; ++i){
-        if(addr.equals(array[i])){
+    for (i = 0; i < len; ++i) {
+        if (addr.equals(array[i])) {
             flag = true;
             break;
         }
@@ -41,10 +41,10 @@ function isAddrExist(array, addr){
  * @param address
  * @return {Session}
  */
-function findSessionByAddr(dic, address){
+function findSessionByAddr(dic, address) {
     let i, len = dic.length, session = null;
-    for(i = 0; i < len; ++i){
-        if(dic[i].key.equals(address)){
+    for (i = 0; i < len; ++i) {
+        if (dic[i].key.equals(address)) {
             session = dic[i].value;
             break;
         }
@@ -58,13 +58,13 @@ function findSessionByAddr(dic, address){
  * @param  {Buffer|String} sortKey
  * @return {Buffer}        hashKeyLen+hashKey+sortKey
  */
-function generateKey(hashKey, sortKey){
+function generateKey(hashKey, sortKey) {
     let temp;
-    if(!Buffer.isBuffer(hashKey)){
+    if (!Buffer.isBuffer(hashKey)) {
         temp = new Buffer(hashKey);
         hashKey = temp;
     }
-    if(!Buffer.isBuffer(sortKey)){
+    if (!Buffer.isBuffer(sortKey)) {
         temp = new Buffer(sortKey);
         sortKey = temp;
     }
@@ -75,7 +75,7 @@ function generateKey(hashKey, sortKey){
     let lenBuf = Buffer.alloc(2);
     lenBuf.writeInt16BE(hashLen, 0);
 
-    return Buffer.concat([lenBuf, hashKey, sortKey], (2+hashLen+sortLen));
+    return Buffer.concat([lenBuf, hashKey, sortKey], (2 + hashLen + sortLen));
 }
 
 /**
@@ -85,23 +85,23 @@ function generateKey(hashKey, sortKey){
  *          {String}  configs.metaServers[i]    ipv4:port
  * @throws  {InvalidParamException}
  */
-function validateClientConfigs(configs){
-    if(!(configs instanceof Object)){
+function validateClientConfigs(configs) {
+    if (!(configs instanceof Object)) {
         throw new InvalidParamException('configs should be instanceof Object');
     }
-    if(!(configs.metaServers instanceof Array)){
+    if (!(configs.metaServers instanceof Array)) {
         throw new InvalidParamException('configs.metaServers should be instanceof Array');
     }
     let i, len = configs.metaServers.length;
-    for(i = 0; i < len; ++i){
+    for (i = 0; i < len; ++i) {
         let ip_port = configs.metaServers[i].split(':');
-        if(ip_port.length !== 2){
+        if (ip_port.length !== 2) {
             throw new InvalidParamException(configs.metaServers[i] + ' is not valid, correct format is ip_address:port');
         }
-        if(!net.isIPv4(ip_port[0])){
+        if (!net.isIPv4(ip_port[0])) {
             throw new InvalidParamException(ip_port[0] + ' is not valid ipv4 address');
         }
-        if(isNaN(ip_port[1]) || ip_port[1] < 0 || ip_port[1] > 65535){
+        if (isNaN(ip_port[1]) || ip_port[1] < 0 || ip_port[1] > 65535) {
             throw new InvalidParamException(ip_port[1] + ' is not valid port');
         }
     }
@@ -113,9 +113,9 @@ function validateClientConfigs(configs){
  * @param   {String}    name
  * @throws  {InvalidParamException}
  */
-function validateFunction(obj, name){
-    if(!(obj instanceof Function)){
-        throw new InvalidParamException('lack of '+name+' or '+name+' is not function');
+function validateFunction(obj, name) {
+    if (!(obj instanceof Function)) {
+        throw new InvalidParamException('lack of ' + name + ' or ' + name + ' is not function');
     }
 }
 
@@ -128,28 +128,28 @@ function validateFunction(obj, name){
  * @param   {Function}      callback
  * @return  {Boolean}       true means return callee function at once
  */
-function validateParam(param, name, type, isObject, callback){
+function validateParam(param, name, type, isObject, callback) {
     let flag = true;
-    if(isObject){
+    if (isObject) {
         flag = (param instanceof type);
         type = type.name;
-    }else{
+    } else {
         flag = (typeof(param) === type);
     }
-    if(!flag){
-        callback(new InvalidParamException(name+':'+param+' is not '+type), null);
+    if (!flag) {
+        callback(new InvalidParamException(name + ':' + param + ' is not ' + type), null);
     }
     return (!flag);
 }
 
 module.exports = {
-    dsn_gpid_to_thread_hash : dsn_gpid_to_thread_hash,
-    isAddrExist : isAddrExist,
-    findSessionByAddr : findSessionByAddr,
-    generateKey : generateKey,
-    validateClientConfigs : validateClientConfigs,
-    validateFunction : validateFunction,
-    validateParam : validateParam,
+    dsn_gpid_to_thread_hash: dsn_gpid_to_thread_hash,
+    isAddrExist: isAddrExist,
+    findSessionByAddr: findSessionByAddr,
+    generateKey: generateKey,
+    validateClientConfigs: validateClientConfigs,
+    validateFunction: validateFunction,
+    validateParam: validateParam,
 };
 
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -298,10 +298,8 @@ describe('test/client.test.js', function(){
                 assert.deepEqual(new Buffer('1'), result[0].value);
                 assert.deepEqual(new Buffer('11'), result[1].sortKey);
                 assert.deepEqual(new Buffer('111'), result[1].value);
-                assert.deepEqual(new Buffer('2'), result[2].sortKey);
-                assert.deepEqual(new Buffer('3'), result[2].value);
-                assert.deepEqual(new Buffer('22'), result[3].sortKey);
-                assert.deepEqual(new Buffer('222'), result[3].value);
+                assert.deepEqual(new Buffer('22'), result[2].sortKey);
+                assert.deepEqual(new Buffer('222'), result[2].value);
                 done();
             });
         });


### PR DESCRIPTION
* Update getConnection
    - Connections are built synchronously using deasync library which will lead to errors while kill tests and unstable state while rolling update cluster, so we should change getConnection to asynchronous execution and remove deasync
* Bug fix
    - repeated cluster replica session which will lead to memory leak
    - useless retry request when handling session errors
    - re-connection while session closed normally
* Enhancement
    - refactor queryMeta to distinguish different table states and add queryMeta delay time
    - update README doc
    - format code