### PR TITLE
fix bug in reconnect meta session

### DIFF
--- a/src/table_handler.js
+++ b/src/table_handler.js
@@ -55,6 +55,15 @@ function TableHandler(cluster, tableName, callback) {
  */
 TableHandler.prototype.queryMeta = function (tableName, callback) {
     let session = this.cluster.metaSession;
+    let leader = session.metaList[session.curLeader];
+
+    // connection has error or closed
+    if (leader.connectError || leader.closed) {
+        session.handleConnectedError(session.curLeader);
+        session.queryingTableName[tableName] = false;
+        session.lastQueryTime[tableName] = 0;
+    }
+
     let queryCfgOperator = new Operator.QueryCfgOperator(new Gpid(-1, -1),
         new replica.query_cfg_request({'app_name': tableName}),
         this.cluster.timeout);


### PR DESCRIPTION
We noticed that client would receive lots of Invalid_state error after finishing rolling update cluster, this pull request fix this bug by refactor code while reconnect meta session