### PR TITLE
Add package-lock.json into .gitignore to avoid useless potential security alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .arcconfig
 *.log*
 node_modules
+package-lock.json


### PR DESCRIPTION
Most packages in package-lock.json are included on my own computer, not project dependency.
Beside, dependency packages are all recorded in package.json, github will still check potential security by checking package.json, it is safe to remove package-lock.json.